### PR TITLE
expose-engines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Logs
 logs
 *.log
+.idea
 
 # Runtime data
 pids

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,63 @@
+{
+    "requireCurlyBraces": [
+        "if",
+        "else",
+        "for",
+        "while",
+        "do",
+        "try",
+        "catch",
+        "switch",
+        "function",
+        "finally"
+    ],
+    "requireSpaceAfterKeywords": [
+        "if",
+        "else",
+        "for",
+        "while",
+        "do",
+        "switch",
+        "case",
+        "return",
+        "try",
+        "catch",
+        "function",
+        "typeof"
+    ],
+    "requireSpaceBeforeBlockStatements": true,
+    "requireParenthesesAroundIIFE": true,
+    "requireSpacesInConditionalExpression": true,
+    "disallowSpacesInNamedFunctionExpression": {
+        "beforeOpeningRoundBrace": true
+    },
+    "disallowSpacesInFunctionDeclaration": {
+        "beforeOpeningRoundBrace": true
+    },
+    "requireMultipleVarDecl": "onevar",
+    "requireBlocksOnNewline": 1,
+    "disallowEmptyBlocks": true,
+    "disallowSpacesInsideArrayBrackets": true,
+    "disallowSpacesInsideParentheses": true,
+    "disallowQuotedKeysInObjects": true,
+    "disallowDanglingUnderscores": true,
+    "disallowSpaceAfterObjectKeys": true,
+    "requireCommaBeforeLineBreak": true,
+    "disallowSpaceAfterPrefixUnaryOperators": true,
+    "disallowSpaceBeforePostfixUnaryOperators": true,
+    "disallowSpaceBeforeBinaryOperators": [
+        ","
+    ],
+    "requireSpaceBeforeBinaryOperators": true,
+    "requireSpaceAfterBinaryOperators": true,
+    "disallowKeywords": [ "with" ],
+    "validateQuoteMarks": "'",
+    "validateIndentation": 2,
+    "disallowMixedSpacesAndTabs": true,
+    "disallowTrailingComma": true,
+    "disallowKeywordsOnNewLine": [ "else" ],
+    "requireCapitalizedConstructors": true,
+    "requireDotNotation": true,
+    "disallowYodaConditions": true,
+    "disallowNewlineBeforeBlockStatements": true
+}

--- a/index.js
+++ b/index.js
@@ -1,20 +1,20 @@
 'use strict';
-var _ = require('lodash'),
+var Self,
+  _ = require('lodash'),
   cons = require('consolidate'),
   render = require('./lib/render');
 
-module.exports = function (instances) {
+Self = function (instances) {
   // if instances are passed through, use them
   if (instances) {
     _.forOwn(instances, function (instance, name) {
       // add them to our engines
-      cons.requires[name] = instance;
+      Self.engines[name] = instance;
     });
   }
-
-  // expose the renderer and the engines
-  return {
-    render: render,
-    engines: cons.engines
-  };
+  return Self;
 };
+Self.render = render;
+Self.engines = cons.requires;
+
+module.exports = Self;

--- a/lib/render.js
+++ b/lib/render.js
@@ -5,7 +5,7 @@ var path = require('path'),
   deasync = require('deasync'),
   cons = require('consolidate'),
   engines = Object.keys(cons),
-  embedTemplate, render;
+  embedTemplate;
 
 // remove consolidate.js helpers
 _.remove(engines, function (prop) {
@@ -14,7 +14,7 @@ _.remove(engines, function (prop) {
 
 /**
  * include static files, e.g. html, png, gifs
- * @param  {string}
+ * @param  {string} file
  * @return {string}
  */
 function includeFile(file) {
@@ -27,32 +27,10 @@ function includeFile(file) {
 }
 
 /**
- * Tries to embed another template into this template
- * @param {string} tpl
- * @param {{}} [data]
- * @param {{}} [extraData]
- */
-embedTemplate = function(tpl, data, extraData) {
-  if (!_.isString(tpl)) {
-    return '';
-  }
-
-  data = data || {};
-
-  // Add extra data.
-  if (_.isObject(extraData)) {
-    data = _.cloneDeep(data); // cloneDeep is necessary for embeds within for loops that have extraData.
-    _.defaults(data, extraData);
-  }
-
-  return render(tpl, data);
-};
-
-/**
  * render a layout or component with some data
- * @param  {string} tpl 
+ * @param  {string} tpl
  * @param  {{}} data
- * @return {Promise}
+ * @return {string}
  */
 function render(tpl, data) {
   var engine, syncRender;
@@ -86,6 +64,28 @@ function render(tpl, data) {
     return includeFile(tpl);
   }
 }
+
+/**
+ * Tries to embed another template into this template
+ * @param {string} tpl
+ * @param {{}} [data]
+ * @param {{}} [extraData]
+ */
+embedTemplate = function (tpl, data, extraData) {
+  if (!_.isString(tpl)) {
+    return '';
+  }
+
+  data = data || {};
+
+  // Add extra data.
+  if (_.isObject(extraData)) {
+    data = _.cloneDeep(data); // cloneDeep is necessary for embeds within for loops that have extraData.
+    _.defaults(data, extraData);
+  }
+
+  return render(tpl, data);
+};
 
 module.exports = render;
 module.exports.embedTemplate = embedTemplate; // for testing

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,54 @@
 'use strict';
 var glob = require('glob'),
   _ = require('lodash'),
-  tests = glob.sync(__dirname + '/../lib/**/*.test.js');
+  tests = glob.sync(__dirname + '/../lib/**/*.test.js'),
+  multiplex = require('../.'),
+  sinon = require('sinon'),
+  expect = require('chai').expect;
 
 _.map(tests, function (test) {
   require(test);
+});
+
+describe('interface', function () {
+
+  var sandbox;
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  it('can stub render on bare function', function () {
+    sandbox.mock(multiplex).expects('render').once();
+
+    expect(function () {
+      multiplex.render();
+    }).to.not.throw();
+
+    sandbox.verify();
+  });
+
+  it('can stub render on function results', function () {
+    sandbox.mock(multiplex).expects('render').once();
+
+    expect(function () {
+      multiplex().render();
+    }).to.not.throw();
+
+    sandbox.verify();
+  });
+
+  it('can replace engines from object or bare function', function () {
+    var newEngine = {},
+      instance = multiplex({thing: newEngine});
+
+    expect(instance.engines.thing).to.equal(newEngine); //not deep equal, but ref equal
+    expect(multiplex.engines.thing).to.equal(newEngine); //not deep equal, but ref equal
+
+    sandbox.verify();
+  });
 });


### PR DESCRIPTION
So we can write tests more easily against things that use this module.

```
  it('can replace engines from object or bare function', function () {
    var newEngine = {},
      instance = multiplex({thing: newEngine});

    expect(instance.engines.thing).to.equal(newEngine); //not deep equal, but ref equal
    expect(multiplex.engines.thing).to.equal(newEngine); //not deep equal, but ref equal

    sandbox.verify();
  });

  it('can stub render on function results', function () {
    sandbox.mock(multiplex).expects('render').once();

    expect(function () {
      multiplex().render();
    }).to.not.throw();

    sandbox.verify();
  });
```
