### PR TITLE
Template engine !== extension

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -30,17 +30,18 @@ function includeFile(file) {
  * render a layout or component with some data
  * @param  {string} tpl
  * @param  {{}} data
+ * @param  {string} engine
  * @return {string}
  */
-function render(tpl, data) {
+function render(tpl, data, engine) {
   var engine, syncRender;
   // "the monk who renders nothing receives only empty strings" -Master Foo
   if (!tpl) {
     return '';
   }
 
-  // grab the template file and find out what engine it uses (from the extension)
-  engine = path.extname(tpl).substring(1); // get rid of the .
+  // grab the template file and find out what engine it uses (from the extension) if no engine name provided
+  engine = engine || path.extname(tpl).substring(1); // get rid of the .
 
   if (_.includes(engines, engine)) {
     // extension is a supported consolidate.js engine!

--- a/lib/render.test.js
+++ b/lib/render.test.js
@@ -25,6 +25,14 @@ describe('render()', function () {
   });
 
   it('should render nunjucks', function () {
+    var tpl = 'foo.njk',
+      engine = 'nunjucks';
+
+    sandbox.stub(glob, 'sync').returns([tpl]);
+    expect(render(tpl, obj, engine)).to.equal('html');
+  });
+
+  it('should infer nunjucks from extension', function () {
     var tpl = 'foo.nunjucks';
 
     sandbox.stub(glob, 'sync').returns([tpl]);
@@ -114,7 +122,7 @@ describe('embedTemplate()', function () {
           }
         }
       });
-      
+
       //NOTE:  Nunjucks is REALLY slow when starting up, so to prevent everyone having to wait for it whenever they run
       // tests, we'll only be testing using a single copy.  Just a warning.
       nunjucks.configure('views', {


### PR DESCRIPTION
The render module assumes that the name of the engine corresponds to file extension. There's several edge cases where this isn't the case.

The community-adopted [standard](https://mozilla.github.io/nunjucks/templating.html) for Nunjucks templates is `.njk` as referenced in this (Clay issue)[https://github.com/nymag/sites/issues/774].

This pull request adds an optional `engine` parameter into `#render` that allows the engine name to be named explicitly rather than inferred from the file extension.
